### PR TITLE
fix(circular-dep): removes circular dependency when using getConfig

### DIFF
--- a/src/modules/utility/get-config.ts
+++ b/src/modules/utility/get-config.ts
@@ -1,10 +1,8 @@
-import * as config from 'config';
-
 export function getConfig<ConfigT>(key: string, fallback?: ConfigT): ConfigT {
-
+    const config = require('config');
     let result: ConfigT;
     try {
-        result = config.get<ConfigT>(key);
+        result = config.get(key);
     }
     catch (error) {
         if (fallback === undefined) {


### PR DESCRIPTION
#### Short description of what this resolves:
Fixes circular dependency caused by getConfig

### PR Checklist
- [x] All `TODO`'s are done and removed
- [x] `package.json` has correct information
- [x] All dependencies are of correct type (regular vs peer vs dev)
- [x] Documented any complicated or confusing code
- [x] No linter errors
- [x] Project packages successfully (`npm pack`)
- [x] Installed local packed version in another project and tested
- [x] Updated README


#### Changes proposed in this pull request:
require the config library within the function

**JIRA Task Link:**