### PR TITLE
feat(error): adds a static error handler that sends errors to raven

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,15 @@
             "integrity": "sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg==",
             "dev": true
         },
+        "@types/raven": {
+            "version": "2.5.3",
+            "resolved": "https://registry.npmjs.org/@types/raven/-/raven-2.5.3.tgz",
+            "integrity": "sha512-k6vxiX5I6/GEqJS9mMYPVIgMJf/X26n09NfzuqBpdcEp684RIwpdrwCgSyJGuy8EaSG1wc2rFP7xVEAixPzw7Q==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
         "ansi-styles": {
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -87,6 +96,11 @@
                 "supports-color": "^5.3.0"
             }
         },
+        "charenc": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+            "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+        },
         "color-convert": {
             "version": "1.9.3",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -122,6 +136,29 @@
                 "json5": "^1.0.1"
             }
         },
+        "cookie": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+            "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+        },
+        "crypt": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+            "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
+        },
+        "date-format": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/date-format/-/date-format-3.0.0.tgz",
+            "integrity": "sha512-eyTcpKOcamdhWJXj56DpQMo1ylSQpcGtGKXcU0Tb97+K56/CF5amAqqqNj0+KvA0iw2ynxtHWFsPDSClCxe48w=="
+        },
+        "debug": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+            "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+            "requires": {
+                "ms": "^2.1.1"
+            }
+        },
         "deepmerge": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.0.0.tgz",
@@ -151,6 +188,21 @@
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
             "dev": true
         },
+        "flatted": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
+            "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg=="
+        },
+        "fs-extra": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+            "requires": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+            }
+        },
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -170,6 +222,11 @@
                 "once": "^1.3.0",
                 "path-is-absolute": "^1.0.0"
             }
+        },
+        "graceful-fs": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+            "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
         },
         "has-flag": {
             "version": "3.0.0",
@@ -192,6 +249,11 @@
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true
+        },
+        "is-buffer": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
         },
         "js-tokens": {
             "version": "4.0.0",
@@ -224,6 +286,36 @@
                 }
             }
         },
+        "jsonfile": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+            "requires": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "log4js": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.1.0.tgz",
+            "integrity": "sha512-fSCHMYsMJbHwfNTuMlopVVcfkKwIRLh5mpNZGB2oBbnSmr3yUTo4tL4xGBA0/q29xowlu96eTXGghJFNhPXMnA==",
+            "requires": {
+                "date-format": "^3.0.0",
+                "debug": "^4.1.1",
+                "flatted": "^2.0.1",
+                "rfdc": "^1.1.4",
+                "streamroller": "^2.2.3"
+            }
+        },
+        "md5": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+            "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+            "requires": {
+                "charenc": "~0.0.1",
+                "crypt": "~0.0.1",
+                "is-buffer": "~1.1.1"
+            }
+        },
         "minimatch": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -248,6 +340,11 @@
                 "minimist": "0.0.8"
             }
         },
+        "ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
         "once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -269,6 +366,18 @@
             "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
             "dev": true
         },
+        "raven": {
+            "version": "2.6.4",
+            "resolved": "https://registry.npmjs.org/raven/-/raven-2.6.4.tgz",
+            "integrity": "sha512-6PQdfC4+DQSFncowthLf+B6Hr0JpPsFBgTVYTAOq7tCmx/kR4SXbeawtPch20+3QfUcQDoJBLjWW1ybvZ4kXTw==",
+            "requires": {
+                "cookie": "0.3.1",
+                "md5": "^2.2.1",
+                "stack-trace": "0.0.10",
+                "timed-out": "4.0.1",
+                "uuid": "3.3.2"
+            }
+        },
         "resolve": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
@@ -277,6 +386,11 @@
             "requires": {
                 "path-parse": "^1.0.6"
             }
+        },
+        "rfdc": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.1.4.tgz",
+            "integrity": "sha512-5C9HXdzK8EAqN7JDif30jqsBzavB7wLpaubisuQIGHWf2gUXSpzy6ArX/+Da8RjFpagWsCn+pIgxTMAmKw9Zug=="
         },
         "semver": {
             "version": "5.7.0",
@@ -290,6 +404,28 @@
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
             "dev": true
         },
+        "stack-trace": {
+            "version": "0.0.10",
+            "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+            "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+        },
+        "streamroller": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-2.2.3.tgz",
+            "integrity": "sha512-AegmvQsscTRhHVO46PhCDerjIpxi7E+d2GxgUDu+nzw/HuLnUdxHWr6WQ+mVn/4iJgMKKFFdiUwFcFRDvcjCtw==",
+            "requires": {
+                "date-format": "^2.1.0",
+                "debug": "^4.1.1",
+                "fs-extra": "^8.1.0"
+            },
+            "dependencies": {
+                "date-format": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/date-format/-/date-format-2.1.0.tgz",
+                    "integrity": "sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA=="
+                }
+            }
+        },
         "supports-color": {
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -298,6 +434,11 @@
             "requires": {
                 "has-flag": "^3.0.0"
             }
+        },
+        "timed-out": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+            "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
         },
         "tslib": {
             "version": "1.10.0",
@@ -340,6 +481,16 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
             "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
             "dev": true
+        },
+        "universalify": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+        },
+        "uuid": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
         },
         "wrappy": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -31,11 +31,14 @@
     "devDependencies": {
         "@types/config": "0.0.34",
         "@types/node": "^12.6.1",
+        "@types/raven": "^2.5.3",
         "tslint": "^5.18.0",
         "typescript": "^3.1.6"
     },
     "dependencies": {
         "config": "^3.2.3",
-        "deepmerge": "^4.0.0"
+        "deepmerge": "^4.0.0",
+        "log4js": "^6.1.0",
+        "raven": "^2.6.4"
     }
 }

--- a/src/modules/error-handler/index.ts
+++ b/src/modules/error-handler/index.ts
@@ -1,0 +1,1 @@
+export * from './static-error-handler';

--- a/src/modules/error-handler/static-error-handler.ts
+++ b/src/modules/error-handler/static-error-handler.ts
@@ -1,0 +1,79 @@
+import * as Raven from 'raven';
+import { Breadcrum } from '../interfaces';
+import { getLogger } from '../utility/get-logger';
+
+/**
+ * This ErrorHandler works as a static class with an app configured for Raven.  No instance has to be
+ * created for this error handler.
+ */
+
+export const RAVEN_DISPLAY_LIMIT = 32752;
+
+export class StaticErrorHandlerService {
+
+    static logger = getLogger();
+
+    static captureBreadcrumb(breadcrumb: Breadcrum) {
+        if (process.env.DEPLOYMENT) {
+            Raven.captureBreadcrumb(breadcrumb);
+        }
+        else {
+            this.logger.info(breadcrumb.message);
+        }
+    }
+
+    static captureException(error: Error) {
+        if (process.env.DEPLOYMENT) {
+            if (this.sizeInBites(error) > RAVEN_DISPLAY_LIMIT) {
+                this.captureMessage(`Error with message "${error.message}" is too large and will not have all data displayed.`);
+            }
+
+            Raven.captureException(error, (e: any) => {
+                if (e) {
+                    this.logger.error(e);
+                }
+            });
+        }
+        else {
+            this.logger.error(error);
+        }
+    }
+
+    static captureMessage(message: string) {
+        if (process.env.DEPLOYMENT) {
+            Raven.captureMessage(message, (e: any) => {
+                if (e) {
+                    this.logger.error(e);
+                }
+            });
+        }
+        else {
+            this.logger.info(message);
+        }
+    }
+
+    private static sizeInBites(object: any) {
+        const objectList = [];
+        const stack = [object];
+        let bytes = 0;
+
+        while (stack.length) {
+            const value = stack.pop();
+
+            if (typeof value === 'boolean') {
+                bytes += 4;
+            }
+            else if (typeof value === 'string') {
+                bytes += value.length * 2;
+            }
+            else if (typeof value === 'number') {
+                bytes += 8;
+            }
+            else if (typeof value === 'object' && value !== null) {
+                objectList.push(value);
+                Object.getOwnPropertyNames(value).forEach((key) => stack.push(value[key]));
+            }
+        }
+        return bytes;
+    }
+}

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -1,3 +1,4 @@
+export * from './error-handler';
 export * from './exceptions';
 export * from './interfaces';
 export * from './node-event-handler';

--- a/src/modules/utility/get-logger.ts
+++ b/src/modules/utility/get-logger.ts
@@ -1,0 +1,10 @@
+import * as log from 'log4js';
+import { getConfig } from './get-config';
+
+export function getLogger() {
+    const level = getConfig('logger.level', 'debug');
+    const logger = log.getLogger();
+    logger.level = level;
+
+    return logger;
+}


### PR DESCRIPTION
#### Short description of what this resolves:
There was no way to send errors to raven outside of a nest context.

### PR Checklist
- [x] All `TODO`'s are done and removed
- [x] `package.json` has correct information
- [x] All dependencies are of correct type (regular vs peer vs dev)
- [x] Documented any complicated or confusing code
- [x] No linter errors
- [x] Project packages successfully (`npm pack`)
- [x] Installed local packed version in another project and tested
- [x] Updated README


#### Changes proposed in this pull request:
- Creates a static error handler

**JIRA Task Link:**