### PR TITLE
feat(config): remove usage of getConfig within the package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -477,9 +477,9 @@
             }
         },
         "typescript": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-            "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.2.tgz",
+            "integrity": "sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==",
             "dev": true
         },
         "universalify": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "@types/node": "^12.6.1",
         "@types/raven": "^2.5.3",
         "tslint": "^5.18.0",
-        "typescript": "^3.1.6"
+        "typescript": "^4.0.0"
     },
     "dependencies": {
         "config": "^3.2.3",

--- a/src/modules/utility/get-logger.ts
+++ b/src/modules/utility/get-logger.ts
@@ -1,8 +1,6 @@
 import * as log from 'log4js';
-import { getConfig } from './get-config';
 
-export function getLogger() {
-    const level = getConfig('logger.level', 'debug');
+export function getLogger(level: string = 'debug') {
     const logger = log.getLogger();
     logger.level = level;
 


### PR DESCRIPTION
#### Short description of what this resolves:
- removes usage of getConfig within the package. Allows for independent config library in implementing apps.

### PR Checklist
- [ ] All `TODO`'s are done and removed
- [ ] `package.json` has correct information
- [ ] All dependencies are of correct type (regular vs peer vs dev)
- [ ] Documented any complicated or confusing code
- [ ] No linter errors
- [ ] Project packages successfully (`npm pack`)
- [ ] Installed local packed version in another project and tested
- [ ] Updated README


#### Changes proposed in this pull request:


**JIRA Task Link:**