### PR TITLE
feat(error-handling): add catchError func to static handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@teamhive/node-common",
-    "version": "3.0.0-alpha.6",
+    "version": "3.0.0-alpha.7",
     "description": "This repo houses our shared node functions and node handlers",
     "keywords": [
         "Typescript"

--- a/src/modules/error-handler/static-error-handler.ts
+++ b/src/modules/error-handler/static-error-handler.ts
@@ -1,7 +1,9 @@
 import { Logger } from 'log4js';
 import * as Raven from 'raven';
 import { Breadcrum } from '../interfaces';
+import { TryCatchException, TryCatchOptions } from '../try-catch';
 import { getLogger } from '../utility/get-logger';
+import { catchError as catchErrorUtil } from '../try-catch/catch-error.util'; 
 
 const DEFAULT_SANITIZE_STACK_LENGTH = 100;
 
@@ -81,6 +83,16 @@ export class StaticErrorHandlerService {
         }
 
         (logger || this.logger).info(message);
+    }
+
+    /**
+     * Use this to catch an error and handle it the same way as the TryCatch decorator outside of situations where
+     * a decorator can be used / is practical
+     */
+    static catchError(error: any, exception: TryCatchException, options?: TryCatchOptions);
+    static catchError(error: any, options: TryCatchOptions);
+    static catchError(error: any, optionsOrException = {} as TryCatchOptions | TryCatchException, options = {} as TryCatchOptions) {
+        catchErrorUtil(error, optionsOrException, options);
     }
 
     private static sizeInBites(object: any) {

--- a/src/modules/try-catch/catch-error.util.ts
+++ b/src/modules/try-catch/catch-error.util.ts
@@ -1,0 +1,68 @@
+import { TryCatchEmitter } from './try-catch-emitter';
+import { TryCatchException } from './try-catch-exception.interface';
+import { TryCatchOptions } from './try-catch-options.interface';
+
+
+export function catchError(error: any, optionsOrException = {} as TryCatchOptions | TryCatchException, options = {} as TryCatchOptions) {
+    // set exception based off of type of second param
+    let exception: TryCatchException;
+    // set options equal to optionsOrException if that param is an object
+    const secondParamOptions = optionsOrException as TryCatchOptions;
+    if (secondParamOptions.customResponseMessage ||
+        secondParamOptions.errorWrapperClass ||
+        secondParamOptions.isSynchronous !== undefined ||
+        secondParamOptions.handleOnly !== undefined) {
+        options = secondParamOptions;
+    }
+    else {
+        exception = optionsOrException as TryCatchException;
+    }
+    
+    // helper function to pass appropriate arguments to exception
+    const getException = (error: any, Exception: TryCatchException) => {
+        if (TryCatchEmitter.baseErrorClass) {
+            if (Array.isArray(TryCatchEmitter.baseErrorClass)) {
+                for (const baseErrorClass of TryCatchEmitter.baseErrorClass) {
+                    if (error instanceof baseErrorClass) {
+                        return error;
+                    }
+                }
+            }
+            else if (error instanceof TryCatchEmitter.baseErrorClass) {
+                return error;
+            }
+        }
+        if (new Exception(error).error) {
+            if (options.customResponseMessage) {
+                return new Exception(error, options.customResponseMessage);
+            }
+            return new Exception(error);
+        }
+    
+        if (options.customResponseMessage) {
+            return new Exception(options.customResponseMessage);
+        }
+        return new Exception();
+    };
+
+    // wrap the error if wrapper passed
+    if (options.errorWrapperClass) {
+        error = new options.errorWrapperClass(error);
+    }
+
+    let scopedException;
+
+    // get exception instance if there is an exception passed in
+    if (exception) {
+        scopedException = getException(error, exception);
+    }
+
+    // if handler passed in capture the exception, otherwise throw it
+    if (options.handleOnly) {
+        // emit for app to subscribe to and handle
+        TryCatchEmitter.emit(scopedException || error);
+    }
+    else {
+        throw scopedException || error;
+    }
+}

--- a/src/modules/try-catch/index.ts
+++ b/src/modules/try-catch/index.ts
@@ -2,3 +2,4 @@ export * from './try-catch-emitter';
 export * from './try-catch-exception.interface';
 export * from './try-catch-options.interface';
 export * from './try-catch.decorator';
+export * from './catch-error.util';

--- a/src/modules/try-catch/try-catch.decorator.ts
+++ b/src/modules/try-catch/try-catch.decorator.ts
@@ -1,71 +1,10 @@
-import { TryCatchEmitter } from './try-catch-emitter';
+import { catchError } from './catch-error.util';
 import { TryCatchException } from './try-catch-exception.interface';
 import { TryCatchOptions } from './try-catch-options.interface';
 
 export function TryCatch(exception: TryCatchException, options?: TryCatchOptions): MethodDecorator;
 export function TryCatch(options: TryCatchOptions): MethodDecorator;
 export function TryCatch(optionsOrException = {} as TryCatchOptions | TryCatchException, options = {} as TryCatchOptions) {
-    // set exception based off of type of first param
-    let exception: TryCatchException;
-    // set options equal to optionsOrException if that param is an object
-    const firstParamOptions = optionsOrException as TryCatchOptions;
-    if (firstParamOptions.customResponseMessage || firstParamOptions.customResponseMessage || firstParamOptions.handleOnly !== undefined) {
-        options = firstParamOptions;
-    }
-    else {
-        exception = optionsOrException as TryCatchException;
-    }
-
-    // helper function to pass appropriate arguments to exception
-    const getException = (error: any, Exception: TryCatchException) => {
-        if (TryCatchEmitter.baseErrorClass) {
-            if (Array.isArray(TryCatchEmitter.baseErrorClass)) {
-                for (const baseErrorClass of TryCatchEmitter.baseErrorClass) {
-                    if (error instanceof baseErrorClass) {
-                        return error;
-                    }
-                }
-            }
-            else if (error instanceof TryCatchEmitter.baseErrorClass) {
-                return error;
-            }
-        }
-        if (new Exception(error).error) {
-            if (options.customResponseMessage) {
-                return new Exception(error, options.customResponseMessage);
-            }
-            return new Exception(error);
-        }
-
-        if (options.customResponseMessage) {
-            return new Exception(options.customResponseMessage);
-        }
-        return new Exception();
-    };
-
-    const catchError = (error: any, handleOnly: boolean) => {
-        // wrap the error if wrapper passed
-        if (firstParamOptions.errorWrapperClass) {
-            error = new firstParamOptions.errorWrapperClass(error);
-        }
-
-        let scopedException;
-
-        // get exception instance if there is an exception passed in
-        if (exception) {
-            scopedException = getException(error, exception);
-        }
-
-        // if handler passed in capture the exception, otherwise throw it
-        if (handleOnly) {
-            // emit for app to subscribe to and handle
-            TryCatchEmitter.emit(scopedException || error);
-        }
-        else {
-            throw scopedException || error;
-        }
-    };
-
     // return the decorator function
     return (_target: any, _key: any, descriptor: any) => {
         // store original method
@@ -79,7 +18,7 @@ export function TryCatch(optionsOrException = {} as TryCatchOptions | TryCatchEx
                     return await originalMethod.apply(this, args);
                 }
                 catch (error) {
-                    catchError(error, !!options.handleOnly);
+                    catchError(error, optionsOrException, options);
                 }
             };
         }
@@ -90,7 +29,7 @@ export function TryCatch(optionsOrException = {} as TryCatchOptions | TryCatchEx
                     return originalMethod.apply(this, args);
                 }
                 catch (error) {
-                    catchError(error, !!options.handleOnly);
+                    catchError(error, optionsOrException, options);
                 }
             };
         }


### PR DESCRIPTION
#### Short description of what this resolves:
add a `catchError` utility function that breaks out the `TryCatch` decorator logic to be used by it and the `StaticErrorHandlerService`

### PR Checklist
- [x] All `TODO`'s are done and removed
- [x] `package.json` has correct information
- [x] All dependencies are of correct type (regular vs peer vs dev)
- [x] Documented any complicated or confusing code
- [x] No linter errors
- [x] Project packages successfully (`npm pack`)
- [x] Installed local packed version in another project and tested
- [ ;)] Updated README


#### Changes proposed in this pull request:


**JIRA Task Link:**