### PR TITLE
feat(honeycomb): support ignored routes by default

### DIFF
--- a/src/modules/utility/set-up-honeycomb-beeline.ts
+++ b/src/modules/utility/set-up-honeycomb-beeline.ts
@@ -1,7 +1,38 @@
 import { BeelineOpts } from '@teamhive/honeycomb-beeline';
 import beeline = require('@teamhive/honeycomb-beeline');
+import deterministicSamplerFactory = require('@teamhive/honeycomb-beeline/lib/deterministic_sampler')
 
-export function setUpHoneycombBeeline(opts: BeelineOpts & {appendEnvToDataset: boolean}) {
+function sampleHookFactory(ignoredRoutes: string[]) {
+    return (data: any) => {
+        // default sample rate to 10
+        let sampleRate = 10;
+    
+        const deterministicSampler = deterministicSamplerFactory(sampleRate);
+
+        let shouldSample = deterministicSampler(data);
+
+        // drop ignoredRoutes
+        if (ignoredRoutes.includes(data["request.path"])) {
+            shouldSample = false;
+            sampleRate = 0;
+        }
+        return {
+            shouldSample,
+            sampleRate
+        }
+    }
+}
+
+
+export function setUpHoneycombBeeline(opts: BeelineOpts & {
+    appendEnvToDataset: boolean;
+    /**
+     * When no custom sampler hook is provided, these routes will be ignored
+     * defaults to /api/v1/versions
+     */
+    ignoredRoutes?: string[]
+}) {
+    const {ignoredRoutes = ['/api/v1/versions']} = opts;
     if (!opts.writeKey) {
         opts.writeKey = process.env.HONEYCOMB_WRITEKEY;
     }
@@ -11,6 +42,9 @@ export function setUpHoneycombBeeline(opts: BeelineOpts & {appendEnvToDataset: b
     }
     if (!opts.serviceName) {
         opts.serviceName = process.env.APP;
+    }
+    if (!opts.samplerHook) {
+        opts.samplerHook = sampleHookFactory(ignoredRoutes)
     }
     beeline(opts);
 }

--- a/src/modules/utility/set-up-honeycomb-beeline.ts
+++ b/src/modules/utility/set-up-honeycomb-beeline.ts
@@ -7,7 +7,7 @@ function sampleHookFactory(ignoredRoutes: string[], sampleRate: number = 1) {
     
         const deterministicSampler = deterministicSamplerFactory(sampleRate);
 
-        let shouldSample = deterministicSampler(data);
+        let { shouldSample } = deterministicSampler(data);
 
         // drop ignoredRoutes
         if (ignoredRoutes.includes(data["request.path"])) {


### PR DESCRIPTION
#### Short description of what this resolves:
- overrides stock sampler handler to allow apps to ignore specific routes
- still allows apps to provide a custom sampler

### PR Checklist
- [ ] All `TODO`'s are done and removed
- [ ] `package.json` has correct information
- [ ] All dependencies are of correct type (regular vs peer vs dev)
- [ ] Documented any complicated or confusing code
- [ ] No linter errors
- [ ] Project packages successfully (`npm pack`)
- [ ] Installed local packed version in another project and tested
- [ ] Updated README


#### Changes proposed in this pull request:


**JIRA Task Link:**