### PR TITLE
fix(honeycomb): create one sampler and do not modify sampleRate

### DIFF
--- a/src/modules/utility/set-up-honeycomb-beeline.ts
+++ b/src/modules/utility/set-up-honeycomb-beeline.ts
@@ -15,7 +15,7 @@ function sampleHookFactory(ignoredRoutes: string[], sampleRate: number = 1) {
         }
         return {
             shouldSample,
-            sampleRate
+            sampleRate: usedSampleRate
         }
     }
 }

--- a/src/modules/utility/set-up-honeycomb-beeline.ts
+++ b/src/modules/utility/set-up-honeycomb-beeline.ts
@@ -3,16 +3,15 @@ import beeline = require('@teamhive/honeycomb-beeline');
 import deterministicSamplerFactory = require('@teamhive/honeycomb-beeline/lib/deterministic_sampler')
 
 function sampleHookFactory(ignoredRoutes: string[], sampleRate: number = 1) {
+    const deterministicSampler = deterministicSamplerFactory(sampleRate);
     return (data: any) => {
-    
-        const deterministicSampler = deterministicSamplerFactory(sampleRate);
-
         let { shouldSample } = deterministicSampler(data);
-
+        let usedSampleRate = sampleRate;
+        
         // drop ignoredRoutes
         if (ignoredRoutes.includes(data["request.path"])) {
             shouldSample = false;
-            sampleRate = 0;
+            usedSampleRate = 0;
         }
         return {
             shouldSample,


### PR DESCRIPTION
#### Short description of what this resolves:
On each request, we were recreating the sampler function.  This was inefficient.  Additionally, we were modifying the sample rate on each function before we return in, thus when the sampler was recreated, it would set to sample rate 0 after an ignored route occurs.  Instead the variable used to return the sample rate for each request is a new variable so chosen sample rate by the app isn't modified.

### PR Checklist
- [ ] All `TODO`'s are done and removed
- [ ] `package.json` has correct information
- [ ] All dependencies are of correct type (regular vs peer vs dev)
- [ ] Documented any complicated or confusing code
- [ ] No linter errors
- [ ] Project packages successfully (`npm pack`)
- [ ] Installed local packed version in another project and tested
- [ ] Updated README


#### Changes proposed in this pull request:


**JIRA Task Link:**