### PR TITLE
feat(honeycomb): update honeycomb usage with errors

### DIFF
--- a/src/modules/try-catch/catch-error.util.ts
+++ b/src/modules/try-catch/catch-error.util.ts
@@ -1,23 +1,12 @@
+import { getTryCatchOptions } from './get-try-catch-options';
 import { TryCatchEmitter } from './try-catch-emitter';
 import { TryCatchException } from './try-catch-exception.interface';
 import { TryCatchOptions } from './try-catch-options.interface';
 
 
 export function catchError(error: any, optionsOrException = {} as TryCatchOptions | TryCatchException, options = {} as TryCatchOptions) {
-    // set exception based off of type of second param
-    let exception: TryCatchException;
-    // set options equal to optionsOrException if that param is an object
-    const secondParamOptions = optionsOrException as TryCatchOptions;
-    if (secondParamOptions.customResponseMessage ||
-        secondParamOptions.errorWrapperClass ||
-        secondParamOptions.isSynchronous !== undefined ||
-        secondParamOptions.handleOnly !== undefined ||
-        secondParamOptions.tags) {
-        options = secondParamOptions;
-    }
-    else {
-        exception = optionsOrException as TryCatchException;
-    }
+    const {exception, tryCatchOptions} = getTryCatchOptions(optionsOrException, options);
+    options = tryCatchOptions;
 
     // append tags to exception or error and return
     const appendTags = (error: any) => {

--- a/src/modules/try-catch/get-try-catch-options.ts
+++ b/src/modules/try-catch/get-try-catch-options.ts
@@ -1,0 +1,23 @@
+import { TryCatchException } from './try-catch-exception.interface';
+import { TryCatchOptions } from './try-catch-options.interface';
+
+export function getTryCatchOptions( optionsOrException = {} as TryCatchOptions | TryCatchException, options = {} as TryCatchOptions) {
+    // set exception based off of type of second param
+    let exception: TryCatchException;
+    // set options equal to optionsOrException if that param is an object
+    const secondParamOptions = optionsOrException as TryCatchOptions;
+    if (secondParamOptions.customResponseMessage ||
+        secondParamOptions.errorWrapperClass ||
+        secondParamOptions.isSynchronous !== undefined ||
+        secondParamOptions.handleOnly !== undefined ||
+        secondParamOptions.tags) {
+        options = secondParamOptions;
+    }
+    else {
+        exception = optionsOrException as TryCatchException;
+    }
+    return {
+        exception,
+        tryCatchOptions: options
+    };
+}

--- a/src/modules/try-catch/try-catch-options.interface.ts
+++ b/src/modules/try-catch/try-catch-options.interface.ts
@@ -1,7 +1,10 @@
+import beeline = require("@teamhive/honeycomb-beeline");
+
 export interface TryCatchOptions {
     handleOnly?: boolean;
     customResponseMessage?: string;
     errorWrapperClass?: { new (param1: Error) };
     isSynchronous?: boolean;
     tags?: { [key: string]: number | string | boolean | bigint | symbol | null | undefined }
+    createTrace?: beeline.MetadataContext
 }

--- a/src/modules/try-catch/try-catch.decorator.ts
+++ b/src/modules/try-catch/try-catch.decorator.ts
@@ -1,6 +1,8 @@
 import { catchError } from './catch-error.util';
+import { getTryCatchOptions } from './get-try-catch-options';
 import { TryCatchException } from './try-catch-exception.interface';
 import { TryCatchOptions } from './try-catch-options.interface';
+import beeline = require('@teamhive/honeycomb-beeline');
 
 export function TryCatch(exception: TryCatchException, options?: TryCatchOptions): MethodDecorator;
 export function TryCatch(options: TryCatchOptions): MethodDecorator;
@@ -10,26 +12,52 @@ export function TryCatch(optionsOrException = {} as TryCatchOptions | TryCatchEx
         // store original method
         const originalMethod = descriptor.value;
 
+        const startTrace = (context: beeline.MetadataContext) => {
+            const traceContext = beeline.getTraceContext()
+            let parentSpanId, traceId: string;
+            if (traceContext) {
+                const traceContextString = beeline.honeycomb.marshalTraceContext(traceContext);
+                let parsedContext = beeline.honeycomb.unmarshalTraceContext(traceContextString);
+                parentSpanId = parsedContext.parentSpanId;
+                traceId = parsedContext.traceId;
+            }
+            return beeline.startTrace(context, traceId, parentSpanId);
+        }
+
         // check if original methods is async
         if (!options.isSynchronous) {
             descriptor.value = async function(...args: any[]) {
+                const {tryCatchOptions} = getTryCatchOptions(optionsOrException, options);
+                let span: beeline.Span;
+                if (tryCatchOptions.createTrace) {
+                    span = startTrace(tryCatchOptions.createTrace);
+                }
                 // try catch the original method passing in args it was called with
                 try {
                     return await originalMethod.apply(this, args);
                 }
                 catch (error) {
                     catchError(error, optionsOrException, options);
+                } finally {
+                    beeline.finishTrace(span);
                 }
             };
         }
         else {
             descriptor.value = function(...args: any[]) {
+                const {tryCatchOptions} = getTryCatchOptions(optionsOrException, options);
+                let span: beeline.Span;
+                if (tryCatchOptions.createTrace) {
+                    span = startTrace(tryCatchOptions.createTrace);
+                }
                 // try catch the original method passing in args it was called with
                 try {
                     return originalMethod.apply(this, args);
                 }
                 catch (error) {
                     catchError(error, optionsOrException, options);
+                } finally {
+                    beeline.finishTrace(span);
                 }
             };
         }


### PR DESCRIPTION
#### Short description of what this resolves:
- allow filtering out urls from honeycomb events. Helpful in remove sentry post events that happen after the request and show up as span with missing parents
- allow creating a trace using try catch decorator. Very helpful in handleOnly situations

### PR Checklist
- [ ] All `TODO`'s are done and removed
- [ ] `package.json` has correct information
- [ ] All dependencies are of correct type (regular vs peer vs dev)
- [ ] Documented any complicated or confusing code
- [ ] No linter errors
- [ ] Project packages successfully (`npm pack`)
- [ ] Installed local packed version in another project and tested
- [ ] Updated README


#### Changes proposed in this pull request:


**JIRA Task Link:**