### PR TITLE
fix(error-handler): fix error handling when base error has no set error

### DIFF
--- a/src/modules/error-handler/static-error-handler.ts
+++ b/src/modules/error-handler/static-error-handler.ts
@@ -100,8 +100,12 @@ export class StaticErrorHandlerService {
         if (errorOrException instanceof TryCatchEmitter.baseErrorClass) {
             const exception = errorOrException;
             const subError = exception.error;
-            subError.name = exception.constructor ? exception.constructor.name : subError.name;
-            error = subError;
+            if (subError && exception.constructor) {
+                subError.name = exception.constructor.name;
+                error = subError;
+            } else {
+                error = exception;
+            }
             tags = exception.tags;
         }
         else {


### PR DESCRIPTION
#### Short description of what this resolves:
In some situations, a custom "base-class" error will reach the error handler but have no "original" error attached to it. Example, would be throwing a BadRequestExample that was prompted by poor user input rather than a javscript error.  In those situations, the error in question is the bad request exception, not a sub error on that instance. The code currently assumes that there will always be a subError

### PR Checklist
- [ ] All `TODO`'s are done and removed
- [ ] `package.json` has correct information
- [ ] All dependencies are of correct type (regular vs peer vs dev)
- [ ] Documented any complicated or confusing code
- [ ] No linter errors
- [ ] Project packages successfully (`npm pack`)
- [ ] Installed local packed version in another project and tested
- [ ] Updated README


#### Changes proposed in this pull request:


**JIRA Task Link:**