### PR TITLE
fix(try-catch): create a trace if no trace exists otherwise use span

### DIFF
--- a/src/modules/try-catch/try-catch.decorator.ts
+++ b/src/modules/try-catch/try-catch.decorator.ts
@@ -15,48 +15,85 @@ export function TryCatch(optionsOrException = {} as TryCatchOptions | TryCatchEx
 
         // check if original methods is async
         if (!options.isSynchronous) {
-            descriptor.value = async function(...args: any[]) {
-                const {tryCatchOptions} = getTryCatchOptions(optionsOrException, options);
-                if (beelineEnabled && tryCatchOptions.createTrace) {
 
-                    return await beeline.startAsyncSpan(tryCatchOptions.createTrace, async (span) => {
-                        // try catch the original method passing in args it was called with
-                        try {
-                            return await originalMethod.apply(this, args);
-                        }
-                        catch (error) {
-                            catchError(error, optionsOrException, options);
-                        } finally {
-                                beeline.finishTrace(span);
-                        }
-                    })
-                } else {
+
+            descriptor.value = async function(...args: any[]) {
+                const runFunctionAsync = async (finallyFn?: () => void) => {
                     try {
                         return await originalMethod.apply(this, args);
                     }
                     catch (error) {
                         catchError(error, optionsOrException, options);
+                    } finally {
+                        if (finallyFn) {
+                            finallyFn()
+                        }
                     }
+                }
+
+                const {tryCatchOptions} = getTryCatchOptions(optionsOrException, options);
+
+                if (beelineEnabled && tryCatchOptions.createTrace) {
+
+                    // if there is no active trace, create one
+                    if (!beeline.getTraceContext()) {
+                        const trace = beeline.startTrace(tryCatchOptions.createTrace);
+                        return await runFunctionAsync(() => {
+                            beeline.finishSpan(trace);
+                        });
+                    }
+                    // if there is an active trace, add a span to the trace 
+                    else {
+                        return await beeline.startAsyncSpan(tryCatchOptions.createTrace, async (span) => {
+                            return await runFunctionAsync(() => {
+                                beeline.finishSpan(span);
+                            })
+                        })
+                    }
+                } 
+                // if tracing is not enabled, just run the function
+                else {
+                    return await runFunctionAsync();
                 }
             };
         }
         else {
             descriptor.value = function(...args: any[]) {
-                const {tryCatchOptions} = getTryCatchOptions(optionsOrException, options);
-                let span: beeline.Span;
-                if (tryCatchOptions.createTrace) {
-                    span = beeline.startSpan(tryCatchOptions.createTrace)
-                }
-                // try catch the original method passing in args it was called with
-                try {
-                    return originalMethod.apply(this, args);
-                }
-                catch (error) {
-                    catchError(error, optionsOrException, options);
-                } finally {
-                    if (span) {
-                        beeline.finishSpan(span);
+
+                const runFunction = (finallyFn?: () => void) => {
+                    try {
+                        return originalMethod.apply(this, args);
                     }
+                    catch (error) {
+                        catchError(error, optionsOrException, options);
+                    } finally {
+                        if (finallyFn) {
+                            finallyFn()
+                        }
+                    }
+                }
+
+                const {tryCatchOptions} = getTryCatchOptions(optionsOrException, options);
+                if (beelineEnabled && tryCatchOptions.createTrace) {
+
+                    // if there is no active trace, create one
+                    if (!beeline.getTraceContext()) {
+                        const trace = beeline.startTrace(tryCatchOptions.createTrace);
+                        return runFunction(() => {
+                            beeline.finishSpan(trace);
+                        });
+                    }
+                    // if there is an active trace, add a span to the trace 
+                    else {
+                        const span = beeline.startSpan()
+                        return runFunction(() => {
+                                beeline.finishSpan(span);
+                        });
+                    }
+                } 
+                // if tracing is not enabled, just run the function
+                else {
+                    return runFunction()
                 }
             };
         }


### PR DESCRIPTION
#### Short description of what this resolves:
- In cases where there is not trace context (i.e. a trace has not been started), the try catch decorator should still create a trace around the function.  This is important in cron scheduled tasks and start up tasks that do not have traces created by a request or message

### PR Checklist
- [ ] All `TODO`'s are done and removed
- [ ] `package.json` has correct information
- [ ] All dependencies are of correct type (regular vs peer vs dev)
- [ ] Documented any complicated or confusing code
- [ ] No linter errors
- [ ] Project packages successfully (`npm pack`)
- [ ] Installed local packed version in another project and tested
- [ ] Updated README


#### Changes proposed in this pull request:


**JIRA Task Link:**