### PR TITLE
feat(honeycomb): support disabling traces via traceContext

### DIFF
--- a/src/modules/utility/set-up-honeycomb-beeline.ts
+++ b/src/modules/utility/set-up-honeycomb-beeline.ts
@@ -15,7 +15,7 @@ function sampleHookFactory(options: {
         let usedSampleRate = sampleRate;
 
         // check for manual ignore
-        if (data[TELEMETRY_DO_NOT_SAMPLE_KEY]) {
+        if (data[TELEMETRY_DO_NOT_SAMPLE_KEY] || `app.${data[TELEMETRY_DO_NOT_SAMPLE_KEY]}`) {
             shouldSample = false;
             usedSampleRate = 0;
         }


### PR DESCRIPTION
#### Short description of what this resolves:
- when you add property honeycomb trace context, it is prepended with `app` such as `app.${propertyName}`.  This change allows us to disable sampling for entire traces from within the application

### PR Checklist
- [ ] All `TODO`'s are done and removed
- [ ] `package.json` has correct information
- [ ] All dependencies are of correct type (regular vs peer vs dev)
- [ ] Documented any complicated or confusing code
- [ ] No linter errors
- [ ] Project packages successfully (`npm pack`)
- [ ] Installed local packed version in another project and tested
- [ ] Updated README


#### Changes proposed in this pull request:


**JIRA Task Link:**